### PR TITLE
Issue #265: Show winrate in deck list

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -266,6 +266,7 @@ var getDecks = function(includeHidden) {
         value.link = `/deck/?deckID=${value.deckID}`
         value.wins = value.wins.length
         value.losses = value.losses.length
+        value.winPercent = Math.round((value.wins / (value.wins + value.losses)) * 100)
         appData.homeDeckList.unshift(value)
       })
     },

--- a/templates/deck-inner.html
+++ b/templates/deck-inner.html
@@ -80,7 +80,7 @@
                     <div rv-each-deck="data.homeDeckList" rv-deckid="deck.deckID" rv-class-deckhidden="deck.hidden">
                         <a rv-href="deck.link" rv-fixhref="" class="list-group-item">
                             <i class="fa fa-leanpub fa-fw"></i> { deck.deckName }
-                            <span class="pull-right text-muted small"><em> { deck.wins } <i class="fa fa-caret-up fa-fw green"></i> / { deck.losses} <i class="fa fa-caret-down fa-fw red"></i></em>
+                            <span class="pull-right text-muted small"><em> { deck.wins } <i class="fa fa-caret-up fa-fw green"></i> / { deck.losses} <i class="fa fa-caret-down fa-fw red"></i></em> (<strong>{ deck.winPercent }%</strong>)
                             </span>
                         </a>
                         <div class="hide-deck" style="display: none;">

--- a/templates/decks-inner.html
+++ b/templates/decks-inner.html
@@ -25,7 +25,7 @@
                     <div rv-each-deck="data.homeDeckList" rv-deckid="deck.deckID">
                         <a rv-href="deck.link" rv-fixhref="" class="list-group-item">
                             <i class="fa fa-leanpub fa-fw"></i> <span rv-class-deckhidden="deck.hidden" class="themeable">{ deck.deckName }</span>
-                            <span class="pull-right text-muted small"><em> { deck.wins } <i class="fa fa-caret-up fa-fw green"></i> / { deck.losses} <i class="fa fa-caret-down fa-fw red"></i></em>
+                            <span class="pull-right text-muted small"><em> { deck.wins } <i class="fa fa-caret-up fa-fw green"></i> / { deck.losses} <i class="fa fa-caret-down fa-fw red"></i></em> (<strong>{ deck.winPercent }%</strong>)
                             </span>
                         </a>
                         <div class="hide-deck" style="display: none;">

--- a/templates/home-inner.html
+++ b/templates/home-inner.html
@@ -58,7 +58,7 @@
                     <div rv-each-deck="data.homeDeckList" rv-deckid="deck.deckID" rv-class-deckhidden="deck.hidden">
                         <a rv-href="deck.link" rv-fixhref="" class="list-group-item">
                             <i class="fa fa-leanpub fa-fw"></i> { deck.deckName }
-                            <span class="pull-right text-muted small"><em> { deck.wins } <i class="fa fa-caret-up fa-fw green"></i> / { deck.losses} <i class="fa fa-caret-down fa-fw red"></i></em>
+                            <span class="pull-right text-muted small"><em> { deck.wins } <i class="fa fa-caret-up fa-fw green"></i> / { deck.losses} <i class="fa fa-caret-down fa-fw red"></i></em> (<strong>{ deck.winPercent }%</strong>)
                             </span>
                         </a>
                         <div class="hide-deck" style="display: none;">


### PR DESCRIPTION
The win percentage (rounded to the nearest integer) of each deck will now show up next to overall wins and losses in the list of decks.